### PR TITLE
Fix `classes` property name in chapter 8

### DIFF
--- a/activities/practice-1/starting-code/src/components/BlogPosts.js
+++ b/activities/practice-1/starting-code/src/components/BlogPosts.js
@@ -1,7 +1,7 @@
 import classes from './BlogPosts.module.css';
 
 function BlogPosts() {
-  return <ul classes={classes.list}></ul>;
+  return <ul className={classes.list}></ul>;
 }
 
 export default BlogPosts;


### PR DESCRIPTION
See title. Looks like a simple typo; my guess is an autocomplete from the `classes` import.